### PR TITLE
fix: Fixed ArticleView Components not popping

### DIFF
--- a/app/components/NewsBlock/NewsBlock.js
+++ b/app/components/NewsBlock/NewsBlock.js
@@ -19,7 +19,7 @@ class NewsBlock extends React.Component {
     Navigation.push("HomeScreen", {
       component: {
         name: "Post.Article",
-        id: "ArticleView",
+        id: `ArticleView${postId}`,
         passProps: {
           postId: postId
         }

--- a/app/components/Post/Article.js
+++ b/app/components/Post/Article.js
@@ -22,7 +22,10 @@ class Article extends React.Component {
     let post = postStore.resolvePost(postId)
     const BULL = " • "
     return (
-      <GenericPost backgroundSource={post.cover_image.url}>
+      <GenericPost
+        childComponentId={this.props.componentId}
+        backgroundSource={post.cover_image.url}
+      >
         <View style={article_styles.credits.container}>
           <Text
             style={article_styles.credits.text}

--- a/app/components/Post/GenericPost.js
+++ b/app/components/Post/GenericPost.js
@@ -31,12 +31,12 @@ class GenericPost extends React.Component {
     this._box.open()
   }
 
-  popScreen = () => {
-    Navigation.pop("ArticleView")
+  popScreen = componentId => {
+    Navigation.pop(componentId)
   }
 
   render() {
-    const { backgroundSource } = this.props
+    const { childComponentId, backgroundSource } = this.props
     return (
       <ReactionButton ref={rxnButton => (this._rxnButton = rxnButton)}>
         <ParallaxScrollView
@@ -57,7 +57,7 @@ class GenericPost extends React.Component {
                 backgroundColor={"transparent"}
                 icon={icons.arrow_back}
                 buttonStyle={styles.header_button}
-                onPress={() => this.popScreen()}
+                onPress={() => this.popScreen(childComponentId)}
               />
             </View>
           )}


### PR DESCRIPTION
Fixed issue where Article Components had the same (instead of a unique) component Id, so when more
than one where pushed into the stack (such as what happens when you click through related posts),
the component can no longer be 'popped' out of the stack.