### PR TITLE
fix: Fixed Sentry Sourcemaps (Removed Broken SentryPlugin)

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -87,34 +87,6 @@ platform :android do
     end
   end
 
-  desc "Upload Android Artifacts to Sentry"
-  lane :upload_artifacts do |options|
-    parsed_options = {
-      :sentry_id => handleEnvAndOptions(
-        ENV["SENTRY_APP_ID"],
-        options[:sentry_id],
-        true,
-        AND_APP_ID
-      )
-    }
-    bundle_artifact = File.join(DIST_DIR, "index.android.bundle")
-    bundle_map = File.join(DIST_DIR, "index.android.bundle.map")
-    UI.important("Uploading Android Build Artifacts to Sentry...")
-    sentry_upload_file(
-      version: AND_VERSION,
-      app_identifier: parsed_options[:sentry_id],
-      file: bundle_artifact,
-      dist: AND_BUILD_NUMBER
-    )
-    sentry_upload_sourcemap(
-      version: AND_VERSION,
-      app_identifier: parsed_options[:sentry_id],
-      sourcemap: bundle_map,
-      dist: AND_BUILD_NUMBER,
-      rewrite: true
-    )
-    UI.success("Android Build Artifacts Uploaded.")
-  end
 
 
   # Clears existing build folders, prevents file duplicate bug
@@ -353,12 +325,6 @@ platform :android do
         options[:apk],
         true,
       ),
-      :sentry_id => handleEnvAndOptions(
-        ENV['SENTRY_APP_ID'],
-        options[:sentry_id],
-        true,
-        AND_APP_ID
-      )
     }
     UI.header("Android Deploy")
     UI.important("
@@ -367,7 +333,6 @@ platform :android do
     APK => #{parsed_options[:apk]}
     RELEASE => #{parsed_options[:sentry_id]}
     ")
-    upload_artifacts(skip_before:true, skip_after:true, sentry_id:parsed_options[:sentry_id])
     appcenter_upload(
       apk: parsed_options[:apk],
       should_clip: false,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -171,7 +171,7 @@ lane :sentry do |options|
   end
   sentry_env = parsed_options[:env].capitalize
   sentry_id = "#{parsed_options[:tag]}-#{TAG_VERSION}"
-  sh("#{SENTRY_SH} release #{sentry_id} #{sentry_env}")
+  sh("#{SENTRY_SH} release #{sentry_id} #{sentry_env} #{BUILD_NUMBER}")
 end
 
 # Create Temporary Keychain for Match (Travis CI)
@@ -248,6 +248,11 @@ lane :deploy do |options|
   dsym_file = Dir["#{DIST_DIR}/*.dSYM.zip"][0]
   sentry_tag = "#{APP_ID}.#{parsed_options[:env]}"
   UI.header("Beginning Deploy")
+  UI.important("Generating iOS Bundle for Sentry...")
+  yarn(
+    command: "ios:bundle",
+    package_path: PACKAGE_JSON
+  )
   UI.important("
     IPA => #{ipa_file}
     APK => #{apk_file}
@@ -263,12 +268,10 @@ lane :deploy do |options|
     :skip_before => true,
     :ipa => ipa_file,
     :dsym => dsym_file,
-    :sentry_id => sentry_tag
   })
   Fastlane::LaneManager.cruise_lane("android", "release", {
     :skip_before => true,
     :apk => apk_file,
-    :sentry_id => sentry_tag,
   })
   UI.important("Finalizing Sentry Release...")
   sentry(tag:sentry_tag, env:parsed_options[:env])

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -49,11 +49,6 @@ Reset App Icons/Edited Files
 fastlane ios certificates
 ```
 Update Match Certificates
-### ios upload_artifacts
-```
-fastlane ios upload_artifacts
-```
-Upload iOS Artifacts to Sentry
 ### ios dev
 ```
 fastlane ios dev
@@ -73,11 +68,6 @@ Release IPA on App Center
 ----
 
 ## Android
-### android upload_artifacts
-```
-fastlane android upload_artifacts
-```
-Upload Android Artifacts to Sentry
 ### android test
 ```
 fastlane android test

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -19,7 +19,6 @@ DISPLAY_NAME = "WarriorBeat".freeze
 # Paths
 BUILT_PRODUCTS_PATH = "#{IOS_PATH}/Build/Build/Products".freeze
 INFO_PLIST_PATH = "#{IOS_PATH}/warriorbeatapp/Info.plist".freeze
-ART_BUNDLE_PATH = "#{IOS_PATH}/bundle".freeze
 
 # Dev
 DEV_PRODUCT = "#{DISPLAY_NAME}-dev.app".freeze
@@ -39,11 +38,6 @@ RELEASE_SCHEME = "#{PROJECT_NAME}".freeze
 
 # App Center
 APPCENTER_APP_NAME = "WarriorBeatApp-1"
-
-# Build Artifacts
-ARTIFACT_DSYM = File.join(ROOT, "#{PROJECT_NAME}.app.dSYM.zip")
-ARTIFACT_BUNDLE = File.join(ART_BUNDLE_PATH, "main.jsbundle")
-ARTIFACT_BUNDLE_MAP = File.join(ART_BUNDLE_PATH, "main.jsbundle.map")
 
 # Version Constants
 VERSION = get_version_number(
@@ -101,53 +95,6 @@ platform :ios do
   lane :certificates do
     match(app_identifier: [DEV_ID, STAGE_ID, APP_ID])
   end
-
-  desc "Upload iOS Artifacts to Sentry"
-  lane :upload_artifacts do |options|
-    parsed_options = {
-      :dsym => handleEnvAndOptions(
-        ENV["IOS_DSYM_OUTPUT"],
-        options[:dsym],
-        true,
-        ARTIFACT_DSYM
-      ),
-      :sentry_id => handleEnvAndOptions(
-        ENV["SENTRY_APP_ID"],
-        options[:sentry_id],
-        true,
-        APP_ID
-      ),
-    }
-
-    UI.important("Uploading iOS Build Artifacts to Sentry...")
-    sentry_upload_dsym(
-      dsym_path: parsed_options[:dsym],
-      info_plist: INFO_PLIST_PATH
-    )
-    UI.important("Generating Bundle for Sentry...")
-    FileUtils.rm(ARTIFACT_BUNDLE) if File.exists?(ARTIFACT_BUNDLE)
-    FileUtils.rm(ARTIFACT_BUNDLE_MAP) if File.exists?(ARTIFACT_BUNDLE_MAP)
-    Dir.mkdir(ART_BUNDLE_PATH) unless File.directory?(ART_BUNDLE_PATH)
-    yarn(
-      command: "ios:bundle",
-      package_path: PACKAGE_JSON
-    )
-    sentry_upload_file(
-      version: VERSION,
-      app_identifier: parsed_options[:sentry_id],
-      file: ARTIFACT_BUNDLE,
-      dist: BUILD_NUMBER
-    )
-    sentry_upload_sourcemap(
-      version: VERSION,
-      app_identifier: parsed_options[:sentry_id],
-      sourcemap: ARTIFACT_BUNDLE_MAP,
-      dist: BUILD_NUMBER,
-      rewrite: true
-    )
-    UI.success("iOS Build Artifacts Uploaded.")
-  end
-
 
   desc "iOS Dev Build"
   lane :dev do |options|
@@ -363,15 +310,8 @@ platform :ios do
         true,
         ARTIFACT_DSYM
       ),
-      :sentry_id => handleEnvAndOptions(
-        ENV["SENTRY_APP_ID"],
-        options[:sentry_id],
-        true,
-        APP_ID
-      ),
     }
     UI.header("iOS Deploy")
-    upload_artifacts(skip_before:true, skip_after: true, dsym: parsed_options[:dsym], sentry_id:parsed_options[:sentry_id])
     UI.important("
     
     Releasing IPA on AppCenter...

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "commit": "git cz",
     "version": "standard-version --commit-all",
     "postinstall": "react-native-schemes-manager all && ./fastlane/scripts/fix_deprecated.sh",
-    "ios:bundle": "react-native bundle --entry-file='index.js' --bundle-output='./ios/bundle/main.jsbundle' --reset-cache --sourcemap-output='./ios/bundle/main.jsbundle.map' --dev=false --platform='ios'",
+    "ios:bundle": "react-native bundle --entry-file='index.js' --bundle-output='./dist/main.jsbundle' --reset-cache --sourcemap-output='./dist/main.jsbundle.map' --dev=false --platform='ios'",
     "ios:bundledev": "react-native bundle --entry-file='index.js' --bundle-output='./ios/main.jsbundle' --dev=true --platform='ios'",
     "gen:changelog": "conventional-changelog -p metahub -i CHANGELOG.md -s -r 0"
   },


### PR DESCRIPTION
Sentry Fastlane currently does not upload sourcemaps correctly, so I replaced it by uploading the sourcemaps in sentry.sh